### PR TITLE
Fixes issue with python version and Google App Engine

### DIFF
--- a/app.yaml
+++ b/app.yaml
@@ -1,4 +1,4 @@
-runtime: python38
+runtime: python312
 
 handlers:
 - url: /

--- a/app.yaml
+++ b/app.yaml
@@ -1,6 +1,4 @@
-runtime: python27
-api_version: 1
-threadsafe: true
+runtime: python38
 
 handlers:
 - url: /


### PR DESCRIPTION
Fixes python version issue with the source code required for the lab:
https://app.qa.com/lab/creating-a-central-authorization-layer-using-cloud-iap/

Changes:
* updates python version to 3.8 as Google  App Engine no longer supports 2.x
* removes directives that are no longer required for Python 3 environments